### PR TITLE
Typo in readme: beta_bimon -> betabinom

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ plot(fit)
 
 ## Tabular presentation of the results
 
-This package includes a function `present_bbfit()` that creates a nicely formatted table of results from fitting a `beta_bimom()` model:
+This package includes a function `present_bbfit()` that creates a nicely formatted table of results from fitting a `beta_binom()` model:
 
 ```R
 present_bbfit(fit, digits = 2)


### PR DESCRIPTION
Fixes a trivial typo in `README.md`: `beta_bimom()` to `beta_binom()` (sorry, ignore the typo [missing _] in the title and commit message :-)
